### PR TITLE
Close connection after deleting

### DIFF
--- a/lib/delete.js
+++ b/lib/delete.js
@@ -21,6 +21,7 @@ const _delete = function (dbOptions,tables) {
         .then( (result) => {
 
             resolve(result);
+            prep.close();
         }, reject);
     });
 };


### PR DESCRIPTION
Resolves #1 

I attempted to add some tests to make sure that both Insert and Delete are calling close when they are done, but I was running into issue using [rewire](https://github.com/jhnns/rewire) and [sinon](https://github.com/sinonjs/sinon) since the `Prepare` module only exports to factory and `Delete` requires it in as a constant.

I can't spend any more time on it today but if you would like the addition tests added I can spend more time on it.