### PR TITLE
Support node 4.x

### DIFF
--- a/lib/readall.js
+++ b/lib/readall.js
@@ -33,6 +33,7 @@ module.exports = function (pattern) {
         return Promise.all(fileMap(files));
     }).then( (fixtures) => {
 
-        return Promise.resolve(Object.assign(...fixtures));
+        //  .apply() is a node 4 alternative to .assign(...fixtures)
+        return Promise.resolve(Object.assign.apply(undefined, fixtures));
     });
 };


### PR DESCRIPTION
The spread operator is nice, but it drops support for node 4.x. Since this is still widely used, and implementing a transpiler like babel would be overkill, I propose we use `.apply()` instead of the spread operator to bring back support for node 4.x.